### PR TITLE
Support PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,9 +1,0 @@
-<?php
-declare(strict_types=1);
-
-include __DIR__ . '/vendor/autoload.php';
-
-return Paysera\PhpCsFixerConfig\Config\PayseraConventionsConfig::create()
-    ->setDefaultFinder(['src', 'tests'], [])
-    ->setRiskyRules()
-;

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       - php: 7.1
         env: COMPOSER_ARGS=""
       - php: 7.2
-        env: COMPOSER_ARGS="" WITH_CS="true"
+        env: COMPOSER_ARGS=""
 
       - php: 7.0
         env: COMPOSER_ARGS="--prefer-lowest"
@@ -35,4 +35,3 @@ before_script:
 
 script:
     - vendor/bin/phpunit
-    - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"; fi

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "paysera/lib-object-wrapper",
+    "name": "donatascn/lib-object-wrapper",
     "description": "Wrapper around JSON-decoded data that lets easily get structured items",
     "autoload": {
         "psr-4": {
@@ -7,12 +7,10 @@
         }
     },
     "require": {
-        "php": "^7.0"
+        "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "paysera/lib-php-cs-fixer-config": "^2.0.0",
-        "friendsofphp/php-cs-fixer": "^2.2,<2.11.2"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,22 +8,11 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php">
 
     <testsuites>
-        <testsuite>
+        <testsuite name="default">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/ObjectWrapper.php
+++ b/src/ObjectWrapper.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Paysera\Component\ObjectWrapper;
 
+use Traversable;
 use ArrayIterator;
 use RuntimeException;
 use stdClass;
@@ -53,27 +54,27 @@ class ObjectWrapper implements ArrayAccess, IteratorAggregate
         return $data;
     }
 
-    public function offsetExists($key)
+    public function offsetExists($offset): bool
     {
-        return isset($this->data->$key);
+        return isset($this->data->$offset);
     }
 
-    public function offsetGet($key)
+    public function offsetGet($offset): mixed
     {
-        return isset($this->data->$key) ? $this->data->$key : null;
+        return isset($this->data->$offset) ? $this->data->$offset : null;
     }
 
-    public function offsetSet($offset, $value)
-    {
-        throw new RuntimeException('Modifying ObjectWrapper is not allowed');
-    }
-
-    public function offsetUnset($offset)
+    public function offsetSet($offset, $value): void
     {
         throw new RuntimeException('Modifying ObjectWrapper is not allowed');
     }
 
-    public function getIterator()
+    public function offsetUnset($offset): void
+    {
+        throw new RuntimeException('Modifying ObjectWrapper is not allowed');
+    }
+
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->data);
     }


### PR DESCRIPTION
- Remove PHP CS because its configuration package is not compatible with PHP 8
- Added return types for methods that implement ArrayAccess to prevent PHP warnings
- Updated PhpUnit configuration